### PR TITLE
Point the CI/CD config towards the `okapi-demo` cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ env:
   global:
     - GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
     - PROJECT_ID=okapi-173322
-    - CLUSTER_NAME=okapi-mod-resource--management-pipeline
-    - CLOUDSDK_COMPUTE_ZONE=us-central1-a
+    - CLUSTER_NAME=okapi-demo
+    - CLOUDSDK_COMPUTE_ZONE=us-east1-b
     - DOCKER_IMAGE_NAME=thefrontside/mod-kb-ebsco
-    - KUBE_DEPLOYMENT_NAME=folio-mod-resource-management
-    - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-resource-management
+    - KUBE_DEPLOYMENT_NAME=folio-mod-kb-ebsco
+    - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-kb-ebsco
 
 install:
   - bundle install

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 bash_escape() ( printf '\\033[%dm' $1; );
 RESET=$(bash_escape 0); BLUE=$(bash_escape 34);


### PR DESCRIPTION
When we were testing this automated deployment with DockerHub and GCE we used an isolated cluster.  Now that we need to tie in Okapi registration, we should point it towards our okapi-demo cluster.